### PR TITLE
Fix 1st item in inventory not triggering stat recalc in mining loadout

### DIFF
--- a/src/loadoutCalc.ts
+++ b/src/loadoutCalc.ts
@@ -42,7 +42,7 @@ export async function calcLoadoutStats(ds: DataStore, miningLoadout: MiningLoado
 
   const laserStats: AllStats[] = await Promise.all(laserStatsPromises)
   const activeGadget =
-    miningLoadout.activeGadgetIndex &&
+    miningLoadout.activeGadgetIndex != undefined &&
     miningLoadout.activeGadgetIndex > -1 &&
     miningLoadout.inventoryGadgets.length > miningLoadout.activeGadgetIndex
       ? cloneDeep(loadoutLookup.gadgets[miningLoadout.inventoryGadgets[miningLoadout.activeGadgetIndex]])


### PR DESCRIPTION
## Description
Fix 1st item in inventory not triggering stat recalculation in mining loadout screens.

Fixes # (issue)
https://github.com/RegolithCo/RegolithCo-Frontend/issues/3

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In mining loadout calculator, add a gadget to loadout. Stat block updates with gadget's effects.